### PR TITLE
Add prominent notes about the waitress issue and tell people to upgrade

### DIFF
--- a/docs/developer/roadmap.rst
+++ b/docs/developer/roadmap.rst
@@ -37,6 +37,15 @@ Zope 5 - stable version
 Plone 6, which is still under development, will use Zope 5.
 
 * Python support:
+    .. warning::
+
+        The default WSGI server component used by Zope, ``waitress``, is
+        affected by `an important security issue
+        <https://github.com/Pylons/waitress/security/advisories/GHSA-4f7p-27jc-3c36>`_.
+        For a fix you must either upgrade to Python 3.7 or higher, or `switch
+        to a different WSGI server
+        <https://zope.readthedocs.io/en/latest/operation.html#recommended-wsgi-servers>`_.
+
     - 3.6 (Deprecated with Zope version 5.5.1, will be dropped in Zope version 5.7)
     - 3.7
     - 3.8
@@ -49,12 +58,27 @@ Plone 6, which is still under development, will use Zope 5.
     - Security fixes: ongoing
 
 
-Zope 4 - previous version
--------------------------
+Zope 4 - bridge from Zope 2 to Zope 5
+-------------------------------------
 The Plone 5.2 release series, which is the current stable release series for
 Plone, uses Zope 4.
 
+Zope 4 supports Python 2 and Python 3. It is meant to act as a bridge for those
+upgrading applications from Zope 2. Once you are on Zope 4 and Python 3 the
+next step to Zope 5 is painless and **we strongly encourage you to move to Zope
+5**.
+
 * Python support:
+
+    .. warning::
+
+        The default WSGI server component used by Zope, ``waitress``, is
+        affected by `an important security issue
+        <https://github.com/Pylons/waitress/security/advisories/GHSA-4f7p-27jc-3c36>`_.
+        For a fix you must either upgrade to Python 3.7 or higher, or `switch
+        to a different WSGI server
+        <https://zope.readthedocs.io/en/latest/operation.html#recommended-wsgi-servers>`_.
+
     - 2.7
     - 3.5
     - 3.6


### PR DESCRIPTION
This PR does the following:

- add a note to the roadmap page about the waitress issue and how to fix it
- encourage people to upgrade from Zope 4 to 5 and stressing the bridging role of Zope 4